### PR TITLE
Revert "fix jquery version to exclude"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,7 @@
     <upstream.version>3.0.2</upstream.version>
     <upstream.url>http://download.cometd.org</upstream.url>
     <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
-    <!-- sync with upstream bundled version -->
-    <jquery.version>2.2.1</jquery.version>
+    <jquery.version>1.8.3</jquery.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
jQuery 2.2.1 doesn't actually exist.

Reverts webjars/cometd-jquery#2
